### PR TITLE
fix: deserialize signed builder bid with proofs

### DIFF
--- a/crates/api/src/proposer/tests.rs
+++ b/crates/api/src/proposer/tests.rs
@@ -32,10 +32,12 @@ pub fn gen_signed_vr() -> SignedValidatorRegistration {
 mod proposer_api_tests {
     // +++ IMPORTS +++
     use crate::{
-        gossiper::{mock_gossiper::MockGossiper, types::GossipedMessage}, proposer::{
+        gossiper::{mock_gossiper::MockGossiper, types::GossipedMessage},
+        proposer::{
             api::{get_nanos_timestamp, ProposerApi},
             PATH_GET_PAYLOAD, PATH_PROPOSER_API,
-        }, test_utils::proposer_api_app
+        },
+        test_utils::proposer_api_app,
     };
 
     use ethereum_consensus::{
@@ -59,8 +61,8 @@ mod proposer_api_tests {
             builder_api::BuilderGetValidatorsResponseEntry, proposer_api::ValidatorRegistrationInfo,
         },
         capella::{self},
-        deneb::{self},
         chain_info::ChainInfo,
+        deneb::{self},
         versioned_payload::PayloadAndBlobs,
         SignedBuilderBid, ValidatorPreferences,
     };
@@ -258,10 +260,13 @@ mod proposer_api_tests {
     }
 
     fn get_signed_builder_bid(value: U256) -> SignedBuilderBid {
-        SignedBuilderBid::Capella(capella::SignedBuilderBid {
-            message: helix_common::eth::capella::BuilderBid { value, ..Default::default() },
-            ..Default::default()
-        })
+        SignedBuilderBid::Capella(
+            capella::SignedBuilderBid {
+                message: helix_common::eth::capella::BuilderBid { value, ..Default::default() },
+                ..Default::default()
+            },
+            None,
+        )
     }
 
     fn get_blinded_beacon_block_body() -> BlindedBeaconBlockBody {
@@ -993,19 +998,23 @@ mod proposer_api_tests {
         let (_gossip_sender, gossip_receiver) = channel::<GossipedMessage>(32);
         let auctioneer = Arc::new(MockAuctioneer::default());
 
-        let prop_api =
-            ProposerApi::<MockAuctioneer, MockDatabaseService, MockMultiBeaconClient, MockGossiper>::new(
-                auctioneer.clone(),
-                Arc::new(MockDatabaseService::default()),
-                Arc::new(MockGossiper::new().unwrap()),
-                vec![],
-                Arc::new(MockMultiBeaconClient::default()),
-                Arc::new(ChainInfo::for_holesky()),
-                slot_update_sender.clone(),
-                Arc::new(ValidatorPreferences::default()),
-                0,
-                gossip_receiver,
-            );
+        let prop_api = ProposerApi::<
+            MockAuctioneer,
+            MockDatabaseService,
+            MockMultiBeaconClient,
+            MockGossiper,
+        >::new(
+            auctioneer.clone(),
+            Arc::new(MockDatabaseService::default()),
+            Arc::new(MockGossiper::new().unwrap()),
+            vec![],
+            Arc::new(MockMultiBeaconClient::default()),
+            Arc::new(ChainInfo::for_holesky()),
+            slot_update_sender.clone(),
+            Arc::new(ValidatorPreferences::default()),
+            0,
+            gossip_receiver,
+        );
 
         let mut x = gen_signed_vr();
 
@@ -1014,17 +1023,16 @@ mod proposer_api_tests {
 
     #[test]
     fn test_verify_signed_blinded_block_signature_from_file_deneb() {
-
         let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
-            if !current_dir.ends_with("api") {
-                current_dir.push("crates/api/");
-            }
-            current_dir.push("test_data/signed_blinded_beacon_block_deneb.json");
-            let req_payload_bytes =
-                load_bytes(current_dir.to_str().expect("Failed to convert path to string"));
+        if !current_dir.ends_with("api") {
+            current_dir.push("crates/api/");
+        }
+        current_dir.push("test_data/signed_blinded_beacon_block_deneb.json");
+        let req_payload_bytes =
+            load_bytes(current_dir.to_str().expect("Failed to convert path to string"));
 
-            let mut decoded_submission: SignedBlindedBeaconBlock =
-                serde_json::from_slice(&req_payload_bytes).unwrap();
+        let mut decoded_submission: SignedBlindedBeaconBlock =
+            serde_json::from_slice(&req_payload_bytes).unwrap();
 
         let chain_info = ChainInfo::for_holesky();
         let slot = decoded_submission.message().slot();
@@ -1043,18 +1051,13 @@ mod proposer_api_tests {
                 );
 
                 match result {
-                    Ok(_) => {
-                        
-                    }
+                    Ok(_) => {}
                     Err(e) => {
                         println!("Error: {:?}", e);
                     }
-                    
                 }
             }
             _ => {}
-            
         }
-        
     }
 }

--- a/crates/common/src/eth/mod.rs
+++ b/crates/common/src/eth/mod.rs
@@ -15,7 +15,6 @@ use ethereum_consensus::{
 };
 
 use helix_utils::signing::sign_builder_message;
-use reth_primitives::proofs;
 use serde::de;
 
 use crate::{
@@ -299,6 +298,14 @@ impl SignedBuilderBid {
             Self::Bellatrix(bid, _) => &bid.message.header.logs_bloom,
             Self::Capella(bid, _) => &bid.message.header.logs_bloom,
             Self::Deneb(bid, _) => &bid.message.header.logs_bloom,
+        }
+    }
+
+    pub fn version(&self) -> &str {
+        match self {
+            Self::Bellatrix(_, _) => "bellatrix",
+            Self::Capella(_, _) => "capella",
+            Self::Deneb(_, _) => "deneb",
         }
     }
 
@@ -633,5 +640,53 @@ mod tests {
         ];
         let res = serde_json::from_slice::<SignedBuilderBid>(&json_bytes);
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_json_signed_builder_bid_with_proofs() {
+        let json = serde_json::json!({
+            "version": "deneb",
+            "data": {
+                "message": {
+                    "header": {
+                        "parent_hash": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "fee_recipient": "0xabcf8e0d4e9587369b2301d0790347320302cc09",
+                        "state_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "receipts_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                        "prev_randao": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "block_number": "1",
+                        "gas_limit": "1",
+                        "gas_used": "1",
+                        "timestamp": "1",
+                        "extra_data": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "base_fee_per_gas": "1",
+                        "blob_gas_used": "1",
+                        "excess_blob_gas": "1",
+                        "block_hash": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "transactions_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                        "withdrawals_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+                    },
+                    "blob_kzg_commitments": [
+                        "0xa94170080872584e54a1cf092d845703b13907f2e6b3b1c0ad573b910530499e3bcd48c6378846b80d2bfa58c81cf3d5"
+                    ],
+                    "value": "1",
+                    "pubkey": "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
+                },
+                "proofs": {
+                    "transaction_hashes": ["0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"],
+                    "generalized_indexes": [4, 5],
+                    "merkle_hashes": ["0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"]
+                },
+                "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+            }
+        });
+
+        let res = serde_json::from_value::<SignedBuilderBid>(json);
+        assert!(res.is_ok());
+
+        let signed_builder_bid = res.unwrap();
+        assert_eq!(signed_builder_bid.version(), "deneb");
+        assert!(matches!(signed_builder_bid, SignedBuilderBid::Deneb(_, Some(_))));
     }
 }

--- a/crates/common/src/proofs.rs
+++ b/crates/common/src/proofs.rs
@@ -1,16 +1,21 @@
 use ethereum_consensus::{
-    bellatrix::presets::minimal::Transaction, deneb::minimal::MAX_TRANSACTIONS_PER_PAYLOAD,
-    phase0::Bytes32, primitives::{BlsPublicKey, BlsSignature}, ssz::prelude::*
+    bellatrix::presets::minimal::Transaction,
+    deneb::minimal::MAX_TRANSACTIONS_PER_PAYLOAD,
+    phase0::Bytes32,
+    primitives::{BlsPublicKey, BlsSignature},
+    ssz::prelude::*,
 };
-use reth_primitives::{TxHash, keccak256, B256};
-use tree_hash::Hash256;
+use reth_primitives::{keccak256, TxHash, B256};
 use sha2::{Digest, Sha256};
+use tree_hash::Hash256;
 
 // Import the new version of the `ssz-rs` crate for multiproof verification.
 use ::ssz_rs as ssz;
 
-use crate::api::constraints_api::{SignableBLS, MAX_CONSTRAINTS_PER_SLOT};
-use crate::eth::SignedBuilderBid;
+use crate::{
+    api::constraints_api::{SignableBLS, MAX_CONSTRAINTS_PER_SLOT},
+    eth::SignedBuilderBid,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProofError {
@@ -36,13 +41,6 @@ impl InclusionProofs {
     pub fn total_leaves(&self) -> usize {
         self.transaction_hashes.len()
     }
-}
-
-#[derive(serde::Deserialize, serde::Serialize)]
-pub struct BidWithProofs {
-    #[serde(flatten)]
-    pub bid: SignedBuilderBid,
-    pub proofs: Option<InclusionProofs>,
 }
 
 pub type HashTreeRoot = tree_hash::Hash256;
@@ -164,8 +162,14 @@ pub fn verify_multiproofs(
 
     // Conversions to the correct types (and versions of the same type)
     let leaves = leaves.into_iter().map(|h| h.as_slice().try_into().unwrap()).collect::<Vec<_>>();
-    let merkle_proofs = proofs.merkle_hashes.to_vec().iter().map(|h| h.as_slice().try_into().unwrap()).collect::<Vec<_>>();
-    let indexes = proofs.generalized_indexes.to_vec().iter().map(|h| *h as usize).collect::<Vec<_>>();
+    let merkle_proofs = proofs
+        .merkle_hashes
+        .to_vec()
+        .iter()
+        .map(|h| h.as_slice().try_into().unwrap())
+        .collect::<Vec<_>>();
+    let indexes =
+        proofs.generalized_indexes.to_vec().iter().map(|h| *h as usize).collect::<Vec<_>>();
     let root = root.as_slice().try_into().expect("Invalid root length");
 
     // Verify the Merkle multiproof against the root

--- a/crates/datastore/src/redis/redis_cache.rs
+++ b/crates/datastore/src/redis/redis_cache.rs
@@ -8,7 +8,15 @@ use ethereum_consensus::{
 };
 use futures_util::TryStreamExt;
 use helix_common::{
-    api::{builder_api::TopBidUpdate, constraints_api::{SignedDelegation, SignedRevocation}}, bid_submission::{v2::header_submission::SignedHeaderSubmission, BidSubmission}, pending_block::PendingBlock, proofs::SignedConstraintsWithProofData, versioned_payload::PayloadAndBlobs, ProposerInfo
+    api::{
+        builder_api::TopBidUpdate,
+        constraints_api::{SignedDelegation, SignedRevocation},
+    },
+    bid_submission::{v2::header_submission::SignedHeaderSubmission, BidSubmission},
+    pending_block::PendingBlock,
+    proofs::SignedConstraintsWithProofData,
+    versioned_payload::PayloadAndBlobs,
+    ProposerInfo,
 };
 use redis::{AsyncCommands, RedisResult, Script, Value};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -16,16 +24,15 @@ use tokio::sync::broadcast;
 use tracing::error;
 
 use helix_common::{
-    proofs::InclusionProofs,
     bid_submission::{BidTrace, SignedBidSubmission},
     eth::SignedBuilderBid,
+    proofs::InclusionProofs,
     signing::RelaySigningContext,
     BuilderInfo,
 };
 use helix_database::types::BuilderInfoDocument;
 
-
-use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
+use tokio_stream::{wrappers::BroadcastStream, Stream, StreamExt};
 
 use crate::{
     error::AuctioneerError,
@@ -34,21 +41,26 @@ use crate::{
         utils::{
             get_builder_latest_bid_time_key, get_builder_latest_bid_value_key,
             get_cache_bid_trace_key, get_cache_get_header_response_key, get_execution_payload_key,
-            get_floor_bid_key, get_floor_bid_value_key, get_latest_bid_by_builder_key,
-            get_latest_bid_by_builder_key_str_builder_pub_key, get_seen_block_hashes_key,
-            get_top_bid_value_key, get_inclusion_proof_key,
+            get_floor_bid_key, get_floor_bid_value_key, get_inclusion_proof_key,
+            get_latest_bid_by_builder_key, get_latest_bid_by_builder_key_str_builder_pub_key,
+            get_seen_block_hashes_key, get_top_bid_value_key,
         },
     },
     types::{
         keys::{
             BUILDER_INFO_KEY, HOUSEKEEPER_LOCK_KEY, LAST_HASH_DELIVERED_KEY,
             LAST_SLOT_DELIVERED_KEY, PROPOSER_WHITELIST_KEY,
-        }, signed_builder_bid_wrapper::SignedBuilderBidWrapper, SaveBidAndUpdateTopBidResponse
+        },
+        signed_builder_bid_wrapper::SignedBuilderBidWrapper,
+        SaveBidAndUpdateTopBidResponse,
     },
     Auctioneer,
 };
 
-use super::utils::{get_constraints_key, get_delegations_key, get_hash_from_hex, get_pending_block_builder_block_hash_key, get_pending_block_builder_key, get_pubkey_from_hex};
+use super::utils::{
+    get_constraints_key, get_delegations_key, get_hash_from_hex,
+    get_pending_block_builder_block_hash_key, get_pending_block_builder_key, get_pubkey_from_hex,
+};
 
 // Constraints expire after 1 epoch = 32 slots.
 const CONSTRAINTS_CACHE_EXPIRY_S: usize = 12 * 32;
@@ -80,11 +92,9 @@ impl RedisCache {
         let cfg = Config::from_url(conn_str);
         let pool = cfg.create_pool(Some(Runtime::Tokio1))?;
         let (tx, mut rx) = broadcast::channel(1000);
-        
+
         // ensure at least one subscriber is running
-        tokio::spawn(async move {
-            while let Ok(_message) = rx.recv().await {}
-        });
+        tokio::spawn(async move { while let Ok(_message) = rx.recv().await {} });
 
         let cache = Self { pool, tx };
 
@@ -106,13 +116,12 @@ impl RedisCache {
         let mut conn = self.pool.get().await?;
 
         while let Some(message) = message_stream.next().await {
-            let payload : String = match message.get_payload(){
+            let payload: String = match message.get_payload() {
                 Ok(payload) => payload,
                 Err(err) => {
                     error!(err=%err, "Failed to get payload from message");
                     continue;
                 }
-            
             };
 
             let data: String = match conn.get(payload).await {
@@ -128,7 +137,6 @@ impl RedisCache {
                     error!(err=%err, "Failed to deserialize data");
                     continue;
                 }
-            
             };
 
             let top_bid_update: TopBidUpdate = sig_bid.into();
@@ -140,7 +148,7 @@ impl RedisCache {
                     continue;
                 }
             };
-            
+
             if let Err(err) = self.tx.send(serialized) {
                 error!(err=%err, "Failed to send top bid update");
                 continue;
@@ -149,7 +157,6 @@ impl RedisCache {
 
         Ok(())
     }
-    
 
     async fn get<T: DeserializeOwned>(&self, key: &str) -> Result<Option<T>, RedisCacheError> {
         let mut conn = self.pool.get().await?;
@@ -200,10 +207,7 @@ impl RedisCache {
         Ok(Some(deserialized_entries))
     }
 
-    async fn hgetall_raw(
-        &self,
-        key: &str,
-    ) -> Result<HashMap<String, Vec<u8>>, RedisCacheError> {
+    async fn hgetall_raw(&self, key: &str) -> Result<HashMap<String, Vec<u8>>, RedisCacheError> {
         let mut conn = self.pool.get().await?;
         let entries: HashMap<String, Vec<u8>> = conn.hgetall(key).await?;
         Ok(entries)
@@ -324,16 +328,16 @@ impl RedisCache {
     ) -> Result<(), RedisCacheError> {
         let mut conn = self.pool.get().await?;
         let mut pipeline = redis::pipe();
-    
+
         // Prepare a vector to hold serialized values
         let mut fields_and_values: Vec<(&str, String)> = Vec::new();
-    
+
         // Iterate over the entries to serialize each value
         for (field, value) in entries {
             let str_val = serde_json::to_string(value)?;
             fields_and_values.push((field, str_val));
         }
-    
+
         // Use hset_multiple for setting multiple fields at once
         pipeline.hset_multiple(key, &fields_and_values);
         pipeline.expire(key, expiry);
@@ -349,7 +353,7 @@ impl RedisCache {
     ) -> Result<(), RedisCacheError> {
         let mut conn = self.pool.get().await?;
         let mut pipeline = redis::pipe();
-    
+
         // Iterate over the entries to serialize each value
         for (field, value) in entries {
             let str_val = serde_json::to_string(value)?;
@@ -422,31 +426,20 @@ impl RedisCache {
         Ok(seen)
     }
 
-    async fn add(
-        &self,
-        key: &str,
-        entry: String,
-    ) -> Result<(), RedisCacheError> {
+    async fn add(&self, key: &str, entry: String) -> Result<(), RedisCacheError> {
         let mut conn = self.pool.get().await?;
         conn.sadd(key, entry).await?;
 
         Ok(())
     }
 
-    async fn remove(
-        &self,
-        key: &str,
-        entries: Vec<String>,
-    ) -> Result<(), RedisCacheError> {
+    async fn remove(&self, key: &str, entries: Vec<String>) -> Result<(), RedisCacheError> {
         let mut conn = self.pool.get().await?;
         conn.srem(key, entries).await?;
         Ok(())
     }
 
-    async fn get_set_members(
-        &self,
-        key: &str,
-    ) -> Result<Vec<String>, RedisCacheError> {
+    async fn get_set_members(&self, key: &str) -> Result<Vec<String>, RedisCacheError> {
         let mut conn = self.pool.get().await?;
         let members: Vec<String> = conn.smembers(key).await?;
         Ok(members)
@@ -543,11 +536,9 @@ impl Auctioneer for RedisCache {
         pub_key: BlsPublicKey,
     ) -> Result<Vec<SignedDelegation>, AuctioneerError> {
         let key = get_delegations_key(&pub_key);
-        
-        let delegations: Option<Vec<SignedDelegation>> = self
-            .get(&key)
-            .await
-            .map_err(AuctioneerError::RedisError)?;
+
+        let delegations: Option<Vec<SignedDelegation>> =
+            self.get(&key).await.map_err(AuctioneerError::RedisError)?;
 
         Ok(delegations.unwrap_or_default())
     }
@@ -559,10 +550,8 @@ impl Auctioneer for RedisCache {
         let key = get_delegations_key(&signed_delegation.message.validator_pubkey);
 
         // Attempt to get the existing delegations from the cache.
-        let delegations: Option<Vec<SignedDelegation>> = self
-            .get(&key)
-            .await
-            .map_err(AuctioneerError::RedisError)?;
+        let delegations: Option<Vec<SignedDelegation>> =
+            self.get(&key).await.map_err(AuctioneerError::RedisError)?;
 
         // Append the new delegation to the existing delegations or create a new Vec if none exist.
         let mut all_delegations = match delegations {
@@ -574,9 +563,7 @@ impl Auctioneer for RedisCache {
         };
 
         // Save the updated delegations back to the cache.
-        self.set(&key, &all_delegations, None)
-            .await
-            .map_err(AuctioneerError::RedisError)
+        self.set(&key, &all_delegations, None).await.map_err(AuctioneerError::RedisError)
     }
 
     async fn revoke_validator_delegation(
@@ -584,26 +571,25 @@ impl Auctioneer for RedisCache {
         signed_revocation: SignedRevocation,
     ) -> Result<(), AuctioneerError> {
         let key = get_delegations_key(&signed_revocation.message.validator_pubkey);
-        
+
         // Attempt to get the existing delegations from the cache.
-        let delegations: Option<Vec<SignedDelegation>> = self
-            .get(&key)
-            .await
-            .map_err(AuctioneerError::RedisError)?;
+        let delegations: Option<Vec<SignedDelegation>> =
+            self.get(&key).await.map_err(AuctioneerError::RedisError)?;
 
         // Filter out the revoked delegation.
         let updated_delegations = match delegations {
             Some(mut delegations) => {
-                delegations.retain(|delegation| delegation.message.delegatee_pubkey != signed_revocation.message.delegatee_pubkey);
+                delegations.retain(|delegation| {
+                    delegation.message.delegatee_pubkey !=
+                        signed_revocation.message.delegatee_pubkey
+                });
                 delegations
             }
             None => Vec::new(),
         };
 
         // Save the updated delegations back to the cache.
-        self.set(&key, &updated_delegations, None)
-            .await
-            .map_err(AuctioneerError::RedisError)
+        self.set(&key, &updated_delegations, None).await.map_err(AuctioneerError::RedisError)
     }
 
     async fn save_constraints(
@@ -612,13 +598,11 @@ impl Auctioneer for RedisCache {
         constraints: SignedConstraintsWithProofData,
     ) -> Result<(), AuctioneerError> {
         let key = get_constraints_key(slot);
-    
+
         // Attempt to get the existing constraints from the cache.
-        let prev_constraints: Option<Vec<SignedConstraintsWithProofData>> = self
-            .get(&key)
-            .await
-            .map_err(AuctioneerError::RedisError)?;
-    
+        let prev_constraints: Option<Vec<SignedConstraintsWithProofData>> =
+            self.get(&key).await.map_err(AuctioneerError::RedisError)?;
+
         // Append the new constraints to the existing constraints or create a new Vec if none exist.
         let mut all_constraints = match prev_constraints {
             Some(mut prev_constraints) => {
@@ -627,7 +611,7 @@ impl Auctioneer for RedisCache {
             }
             None => Vec::from([constraints]),
         };
-    
+
         // Save the updated constraints back to the cache.
         self.set(&key, &all_constraints, Some(CONSTRAINTS_CACHE_EXPIRY_S))
             .await
@@ -727,10 +711,11 @@ impl Auctioneer for RedisCache {
         Ok(wrapped_bid.map(|wrapped_bid| wrapped_bid.bid))
     }
 
-    async fn get_best_bids(&self) -> Box<dyn Stream<Item = Result<Vec<u8>, AuctioneerError>> + Send + Unpin> {
+    async fn get_best_bids(
+        &self,
+    ) -> Box<dyn Stream<Item = Result<Vec<u8>, AuctioneerError>> + Send + Unpin> {
         let rx = self.tx.subscribe();
-        let stream = BroadcastStream::new(rx)
-            .map_err(AuctioneerError::from);
+        let stream = BroadcastStream::new(rx).map_err(AuctioneerError::from);
         Box::new(stream)
     }
 
@@ -801,9 +786,15 @@ impl Auctioneer for RedisCache {
         let mut conn = self.pool.get().await.map_err(RedisCacheError::from)?;
         let mut pipe = redis::pipe();
 
-        let wrapped_builder_bid = SignedBuilderBidWrapper::new(builder_bid.clone(), slot, builder_pub_key.clone(), received_at);
+        let wrapped_builder_bid = SignedBuilderBidWrapper::new(
+            builder_bid.clone(),
+            slot,
+            builder_pub_key.clone(),
+            received_at,
+        );
 
-        let serialised_bid = serde_json::to_string(&wrapped_builder_bid).map_err(RedisCacheError::from)?;
+        let serialised_bid =
+            serde_json::to_string(&wrapped_builder_bid).map_err(RedisCacheError::from)?;
         let serialised_value =
             serde_json::to_string(&builder_bid.value()).map_err(RedisCacheError::from)?;
 
@@ -872,6 +863,7 @@ impl Auctioneer for RedisCache {
         let mut cloned_submission = (*submission).clone();
         let builder_bid = SignedBuilderBid::from_submission(
             &mut cloned_submission,
+            None, // Note: inclusion proofs are saved separately in the cache.
             signing_context.public_key.clone(),
             &signing_context.signing_key,
             &signing_context.context,
@@ -1123,6 +1115,7 @@ impl Auctioneer for RedisCache {
         // Sign builder bid with relay pubkey.
         let builder_bid = SignedBuilderBid::from_header_submission(
             submission,
+            None, // Note: inclusion proofs are saved separately in the cache.
             signing_context.public_key.clone(),
             &signing_context.signing_key,
             &signing_context.context,
@@ -1188,15 +1181,11 @@ impl Auctioneer for RedisCache {
         block_hash: &Hash32,
         timestamp_ms: u64,
     ) -> Result<(), AuctioneerError> {
-
         let builder_key = get_pending_block_builder_key(builder_pub_key);
         self.add(builder_key.as_str(), format!("{block_hash:?}")).await?;
 
         let key = get_pending_block_builder_block_hash_key(builder_pub_key, block_hash);
-        let entries = vec![
-            ("slot", slot),
-            ("header_received", timestamp_ms),
-        ];
+        let entries = vec![("slot", slot), ("header_received", timestamp_ms)];
         self.hset_multiple_not_exists(key.as_str(), &entries, PENDING_BLOCK_EXPIRY_S).await?;
 
         Ok(())
@@ -1209,22 +1198,17 @@ impl Auctioneer for RedisCache {
         block_hash: &Hash32,
         timestamp_ms: u64,
     ) -> Result<(), AuctioneerError> {
-
         let builder_key = get_pending_block_builder_key(builder_pub_key);
         self.add(builder_key.as_str(), format!("{block_hash:?}")).await?;
 
         let key = get_pending_block_builder_block_hash_key(builder_pub_key, block_hash);
-        let entries = vec![
-            ("slot", slot),
-            ("payload_received", timestamp_ms),
-        ];
+        let entries = vec![("slot", slot), ("payload_received", timestamp_ms)];
         self.hset_multiple_not_exists(key.as_str(), &entries, PENDING_BLOCK_EXPIRY_S).await?;
 
         Ok(())
     }
 
     async fn get_pending_blocks(&self) -> Result<Vec<PendingBlock>, AuctioneerError> {
-
         let mut pending_blocks: Vec<PendingBlock> = Vec::new();
 
         let redis_builder_infos: Option<HashMap<String, BuilderInfo>> =
@@ -1233,7 +1217,7 @@ impl Auctioneer for RedisCache {
         if redis_builder_infos.is_none() {
             return Ok(pending_blocks);
         }
-        
+
         for (bulder_pub_key_str, builder_info) in redis_builder_infos.unwrap() {
             let mut expired: Vec<String> = Vec::new();
 
@@ -1241,12 +1225,14 @@ impl Auctioneer for RedisCache {
             let builder_key: String = get_pending_block_builder_key(&builder_pubkey);
 
             if builder_info.is_optimistic {
-                
                 let block_hashes: Vec<String> = self.get_set_members(builder_key.as_str()).await?;
                 let builder_pubkey_clone = builder_pubkey.clone();
                 for block_hash_str in block_hashes {
                     let block_hash = get_hash_from_hex(&block_hash_str)?;
-                    let key = get_pending_block_builder_block_hash_key(&builder_pubkey_clone, &block_hash);
+                    let key = get_pending_block_builder_block_hash_key(
+                        &builder_pubkey_clone,
+                        &block_hash,
+                    );
                     let pending_block = self.hgetall_raw(key.as_str()).await?;
 
                     if pending_block.is_empty() {
@@ -1270,7 +1256,7 @@ impl Auctioneer for RedisCache {
                     };
 
                     let pending_block = PendingBlock {
-                        slot: slot,
+                        slot,
                         block_hash,
                         builder_pubkey: builder_pubkey_clone.clone(),
                         header_receive_ms: header_received,
@@ -2397,32 +2383,25 @@ mod tests {
         let cache = RedisCache::new("redis://127.0.0.1/", Vec::new()).await.unwrap();
         cache.clear_cache().await.unwrap();
 
-        let builder_infos = vec![
-            BuilderInfoDocument {
-                builder_info: BuilderInfo{
-                    collateral: U256::from(100),
-                    is_optimistic: true,
-                    builder_id: None,
-                },
-                pub_key: BlsPublicKey::default(),
-            }
-        ];
+        let builder_infos = vec![BuilderInfoDocument {
+            builder_info: BuilderInfo {
+                collateral: U256::from(100),
+                is_optimistic: true,
+                builder_id: None,
+            },
+            pub_key: BlsPublicKey::default(),
+        }];
 
         cache.update_builder_infos(builder_infos).await.unwrap();
-        
 
         let slot = 42;
         let block_hash = Hash32::try_from([5u8; 32].as_ref()).unwrap();
         let builder_pub_key = BlsPublicKey::default();
         let time = 1616237123000u64;
 
-        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
-        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
         let pending_blocks = cache.get_pending_blocks().await.unwrap();
 
@@ -2440,32 +2419,32 @@ mod tests {
         let cache = RedisCache::new("redis://127.0.0.1/", Vec::new()).await.unwrap();
         cache.clear_cache().await.unwrap();
 
-        let builder_infos = vec![
-            BuilderInfoDocument {
-                builder_info: BuilderInfo{
-                    collateral: U256::from(100),
-                    is_optimistic: true,
-                    builder_id: None,
-                },
-                pub_key: BlsPublicKey::default(),
-            }
-        ];
+        let builder_infos = vec![BuilderInfoDocument {
+            builder_info: BuilderInfo {
+                collateral: U256::from(100),
+                is_optimistic: true,
+                builder_id: None,
+            },
+            pub_key: BlsPublicKey::default(),
+        }];
 
         cache.update_builder_infos(builder_infos).await.unwrap();
 
         let mut expected_pending_blocks = Vec::new();
-        
+
         for i in 0..10 {
             let slot = i as u64;
             let block_hash = Hash32::try_from([i; 32].as_ref()).unwrap();
             let builder_pub_key = BlsPublicKey::default();
             let time = get_current_unix_time_in_nanos() as u64;
 
-            cache.save_pending_block_header(slot, &builder_pub_key, &block_hash,  time)
+            cache
+                .save_pending_block_header(slot, &builder_pub_key, &block_hash, time)
                 .await
                 .unwrap();
 
-            cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash,  time)
+            cache
+                .save_pending_block_payload(slot, &builder_pub_key, &block_hash, time)
                 .await
                 .unwrap();
 
@@ -2503,28 +2482,23 @@ mod tests {
         let cache = RedisCache::new("redis://127.0.0.1/", Vec::new()).await.unwrap();
         cache.clear_cache().await.unwrap();
 
-        let builder_infos = vec![
-            BuilderInfoDocument {
-                builder_info: BuilderInfo{
-                    collateral: U256::from(100),
-                    is_optimistic: true,
-                    builder_id: None,
-                },
-                pub_key: BlsPublicKey::default(),
-            }
-        ];
+        let builder_infos = vec![BuilderInfoDocument {
+            builder_info: BuilderInfo {
+                collateral: U256::from(100),
+                is_optimistic: true,
+                builder_id: None,
+            },
+            pub_key: BlsPublicKey::default(),
+        }];
 
         cache.update_builder_infos(builder_infos).await.unwrap();
-        
 
         let slot = 42;
         let block_hash = Hash32::try_from([5u8; 32].as_ref()).unwrap();
         let builder_pub_key = BlsPublicKey::default();
         let time = 1616237123000u64;
 
-        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
         let pending_blocks = cache.get_pending_blocks().await.unwrap();
 
@@ -2542,28 +2516,23 @@ mod tests {
         let cache = RedisCache::new("redis://127.0.0.1/", Vec::new()).await.unwrap();
         cache.clear_cache().await.unwrap();
 
-        let builder_infos = vec![
-            BuilderInfoDocument {
-                builder_info: BuilderInfo{
-                    collateral: U256::from(100),
-                    is_optimistic: true,
-                    builder_id: None,
-                },
-                pub_key: BlsPublicKey::default(),
-            }
-        ];
+        let builder_infos = vec![BuilderInfoDocument {
+            builder_info: BuilderInfo {
+                collateral: U256::from(100),
+                is_optimistic: true,
+                builder_id: None,
+            },
+            pub_key: BlsPublicKey::default(),
+        }];
 
         cache.update_builder_infos(builder_infos).await.unwrap();
-        
 
         let slot = 42;
         let block_hash = Hash32::try_from([5u8; 32].as_ref()).unwrap();
         let builder_pub_key = BlsPublicKey::default();
         let time = 1616237123000u64;
 
-        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
         let pending_blocks = cache.get_pending_blocks().await.unwrap();
 
@@ -2581,34 +2550,28 @@ mod tests {
         let cache = RedisCache::new("redis://127.0.0.1/", Vec::new()).await.unwrap();
         cache.clear_cache().await.unwrap();
 
-        let builder_infos = vec![
-            BuilderInfoDocument {
-                builder_info: BuilderInfo{
-                    collateral: U256::from(100),
-                    is_optimistic: true,
-                    builder_id: None,
-                },
-                pub_key: BlsPublicKey::default(),
-            }
-        ];
+        let builder_infos = vec![BuilderInfoDocument {
+            builder_info: BuilderInfo {
+                collateral: U256::from(100),
+                is_optimistic: true,
+                builder_id: None,
+            },
+            pub_key: BlsPublicKey::default(),
+        }];
 
         cache.update_builder_infos(builder_infos).await.unwrap();
-        
 
         let slot = 42;
         let block_hash = Hash32::try_from([5u8; 32].as_ref()).unwrap();
         let builder_pub_key = BlsPublicKey::default();
         let time = 1616237123000u64;
 
-        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_header(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
-        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash,  time)
-            .await
-            .unwrap();
+        cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash, time).await.unwrap();
 
-            cache.save_pending_block_payload(slot, &builder_pub_key, &block_hash,  1716237123000u64)
+        cache
+            .save_pending_block_payload(slot, &builder_pub_key, &block_hash, 1716237123000u64)
             .await
             .unwrap();
 
@@ -2632,9 +2595,8 @@ mod tests {
         let proposer_pub_key = BlsPublicKey::default();
         let bid_block_hash = Hash32::try_from([5u8; 32].as_ref()).unwrap();
 
-        let inclusion_proof = InclusionProofs {
-            proofs: vec!["proof1".to_string(), "proof2".to_string()],
-        };
+        let inclusion_proof =
+            InclusionProofs { proofs: vec!["proof1".to_string(), "proof2".to_string()] };
 
         // Test: Save inclusion proof
         let save_result = cache
@@ -2643,9 +2605,7 @@ mod tests {
         assert!(save_result.is_ok(), "Failed to save inclusion proof");
 
         // Test: Get inclusion proof
-        let get_result = cache
-            .get_inclusion_proof(slot, &proposer_pub_key, &bid_block_hash)
-            .await;
+        let get_result = cache.get_inclusion_proof(slot, &proposer_pub_key, &bid_block_hash).await;
         assert!(get_result.is_ok(), "Failed to get inclusion proof");
         assert_eq!(
             get_result.unwrap(),
@@ -2654,10 +2614,12 @@ mod tests {
         );
 
         // Test: Get non-existent inclusion proof
-        let non_existent_proof = cache
-            .get_inclusion_proof(slot + 1, &proposer_pub_key, &bid_block_hash)
-            .await;
+        let non_existent_proof =
+            cache.get_inclusion_proof(slot + 1, &proposer_pub_key, &bid_block_hash).await;
         assert!(non_existent_proof.is_ok(), "Failed to get non-existent inclusion proof");
-        assert!(non_existent_proof.unwrap().is_none(), "Expected None for non-existent inclusion proof");
+        assert!(
+            non_existent_proof.unwrap().is_none(),
+            "Expected None for non-existent inclusion proof"
+        );
     }
 }

--- a/crates/datastore/src/types/signed_builder_bid_wrapper.rs
+++ b/crates/datastore/src/types/signed_builder_bid_wrapper.rs
@@ -10,23 +10,23 @@ pub struct SignedBuilderBidWrapper {
 }
 
 impl SignedBuilderBidWrapper {
-    pub fn new(bid: SignedBuilderBid, slot: u64, builder_pub_key: BlsPublicKey, received_at: u128) -> Self {
+    pub fn new(
+        bid: SignedBuilderBid,
+        slot: u64,
+        builder_pub_key: BlsPublicKey,
+        received_at: u128,
+    ) -> Self {
         // convert received_at to millis, from nanos.
         let received_at = received_at / 1_000_000;
 
-        Self {
-            bid,
-            slot,
-            builder_pub_key,
-            received_at_ms: received_at as u64,
-        }
+        Self { bid, slot, builder_pub_key, received_at_ms: received_at as u64 }
     }
 }
 
 impl Into<TopBidUpdate> for SignedBuilderBidWrapper {
     fn into(self) -> TopBidUpdate {
         match self.bid {
-            SignedBuilderBid::Bellatrix(bid) => TopBidUpdate {
+            SignedBuilderBid::Bellatrix(bid, _) => TopBidUpdate {
                 timestamp: self.received_at_ms,
                 slot: self.slot,
                 block_number: bid.message.header.block_number,
@@ -36,7 +36,7 @@ impl Into<TopBidUpdate> for SignedBuilderBidWrapper {
                 fee_recipient: bid.message.header.fee_recipient,
                 value: bid.message.value,
             },
-            SignedBuilderBid::Capella(bid) => TopBidUpdate {
+            SignedBuilderBid::Capella(bid, _) => TopBidUpdate {
                 timestamp: self.received_at_ms,
                 slot: self.slot,
                 block_number: bid.message.header.block_number,
@@ -46,7 +46,7 @@ impl Into<TopBidUpdate> for SignedBuilderBidWrapper {
                 fee_recipient: bid.message.header.fee_recipient,
                 value: bid.message.value,
             },
-            SignedBuilderBid::Deneb(bid) => TopBidUpdate {
+            SignedBuilderBid::Deneb(bid, _) => TopBidUpdate {
                 timestamp: self.received_at_ms,
                 slot: self.slot,
                 block_number: bid.message.header.block_number,


### PR DESCRIPTION
The `SignedBuilderBid` object now contains optional `InclusionProofs` and implements the serde traits manually.

Note: when saving the bid in the auctioneer, we still save the `BuilderBid` and `IncusionProofs` separately with two different functions. I left this as is in order to minimize changes here but it would be more ideal if it was done in the same function.