### PR TITLE
fix: beacon node timeout increased

### DIFF
--- a/crates/beacon-client/src/beacon_client.rs
+++ b/crates/beacon-client/src/beacon_client.rs
@@ -24,7 +24,10 @@ use crate::{
 };
 
 const CONSENSUS_VERSION_HEADER: &str = "eth-consensus-version";
-const BEACON_CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+// Note: we noticed that beacon clients can take 5-10s to respond with the full 
+// validators list in some cases. The previous timeout of 5s was too short.
+const BEACON_CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 #[derive(Clone, Debug)]
 pub struct BeaconClient {


### PR DESCRIPTION
This is necessary after we noticed the following error on our holesky deployment:

```
2024-10-24T12:20:55.763914Z ERROR helix_housekeeper::housekeeper: failed to fetch validators err=Reqwest error: error sending request for url (http://beacon:4000/eth/v1/beacon/states/head/validators?status=active,p
ending): operation timed out
```

Upon inspection our beacon node takes ~6s to respond with all active validators, while the timeout was hard-coded at 5s.

```
docker exec -it holesky-helix-relay-1 curl http://beacon:4000/eth/v1/beacon/states/head/validators?status=active,pending -o /dev/null -s -w "%{time_total}\n"

5.9
```

This PR temporarily increases the timeout but it wouldn't be a bad idea to have this as a configuration option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased timeout for beacon client requests from 5 seconds to 15 seconds to better accommodate response times. 

This enhancement ensures a smoother user experience by reducing the likelihood of premature timeouts when retrieving data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->