### PR TITLE
feat(constraints-api): add startup configuration

### DIFF
--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -188,11 +188,14 @@ impl ApiService {
 
         let data_api = Arc::new(DataApiProd::new(validator_preferences.clone(), db.clone()));
 
+        let constraints_api_config = Arc::new(config.constraints_api_config);
+
         let constraints_api = Arc::new(ConstraintsApiProd::new(
             auctioneer.clone(),
             db.clone(),
             chain_info.clone(),
             constraints_handle,
+            constraints_api_config,
         ));
 
         let bids_cache: Arc<BidsCache> = Arc::new(

--- a/crates/api/src/test_utils.rs
+++ b/crates/api/src/test_utils.rs
@@ -6,7 +6,7 @@ use axum::{
     routing::{get, post},
     BoxError, Extension, Router,
 };
-use helix_common::{chain_info::ChainInfo, RelayConfig, Route};
+use helix_common::{chain_info::ChainInfo, ConstraintsApiConfig, RelayConfig, Route};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 use helix_beacon_client::{
@@ -328,6 +328,7 @@ pub fn constraints_api_app() -> (
             database.clone(),
             Arc::new(ChainInfo::for_mainnet()),
             handler,
+            Arc::new(ConstraintsApiConfig::default()),
         ));
 
     let router = Router::new()

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -32,6 +32,8 @@ pub struct RelayConfig {
     #[serde(default = "default_duration")]
     pub target_get_payload_propagation_duration_ms: u64,
     #[serde(default)]
+    pub constraints_api_config: ConstraintsApiConfig,
+    #[serde(default)]
     pub primev_config: Option<PrimevConfig>,
     /// Submissions from these builder pubkeys will never be dropped early
     /// for having a low bid. They will always be simulated and fully verified.
@@ -123,6 +125,23 @@ pub enum NetworkConfig {
         genesis_validator_root: Node,
         genesis_time: u64,
     },
+}
+
+/// Configuration for the [Constraints API](https://docs.boltprotocol.xyz/technical-docs/api/builder)
+///
+/// These checks are enabled by default. Disabling them is recommended only for testing purposes.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ConstraintsApiConfig {
+    /// If `false`, the constraints signature via the
+    /// [`/constraints/v1/builder/constraints`](https://docs.boltprotocol.xyz/technical-docs/api/builder#constraints)
+    /// endpoint will not be checked.
+    pub check_constraints_signature: bool,
+}
+
+impl Default for ConstraintsApiConfig {
+    fn default() -> Self {
+        ConstraintsApiConfig { check_constraints_signature: true }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]


### PR DESCRIPTION
Adds the `ConstraintsApiConfig` struct that allows disabling some signature checks if needed.