### PR TITLE
Determine valid constraint blocks without proof

### DIFF
--- a/crates/api/src/builder/api.rs
+++ b/crates/api/src/builder/api.rs
@@ -679,42 +679,10 @@ where
             .await?;
 
         // Fetch constraints, and if available verify inclusion proofs and save them to cache
-        if let Some(constraints) = api.auctioneer.get_constraints(payload.slot()).await? {
-            let transactions_root: B256 = payload
-                .transactions()
-                .clone()
-                .hash_tree_root()?
-                .to_vec()
-                .as_slice()
-                .try_into()
-                .map_err(|e| {
-                    error!(error = %e, "failed to convert root to hash32");
-                    BuilderApiError::InternalError
-                })?;
-            let proofs = payload.proofs().ok_or(BuilderApiError::InclusionProofsNotFound)?;
-            let constraints_proofs: Vec<_> = constraints.iter().map(|c| &c.proof_data).collect();
-
-            verify_multiproofs(constraints_proofs.as_slice(), proofs, transactions_root).map_err(
-                |e| {
-                    error!(error = %e, "failed to verify inclusion proofs");
-                    BuilderApiError::InclusionProofVerificationFailed(e)
-                },
-            )?;
-
-            // Save inclusion proof to auctioneer.
-            api.save_inclusion_proof(
-                payload.slot(),
-                payload.proposer_public_key(),
-                payload.block_hash(),
-                proofs,
-                &request_id,
-            )
-            .await?;
-
-            info!(request_id = %request_id, head_slot, "inclusion proofs verified and saved to auctioneer");
-        } else {
-            info!(request_id = %request_id, "no constraints found for slot, proof verification is not needed");
-        };
+        if let Err(err) = api.verify_and_save_inclusion_proofs(&payload, &request_id).await {
+            warn!(request_id = %request_id, error = %err, "failed to verify and save inclusion proofs");
+            return Err(err)
+        }
 
         // If cancellations are enabled, then abort now if there is a later submission
         if is_cancellations_enabled {
@@ -2197,6 +2165,61 @@ where
             );
         }
     }
+
+    /// Fetch constraints, and if available verify inclusion proofs and save them to cache.
+    async fn verify_and_save_inclusion_proofs(
+        api: &BuilderApi<A, DB, S, G>,
+        payload: &SignedBidSubmissionDeneb,
+        request_id: Uuid,
+    ) -> Result<(), BuilderApiError> {
+        if let Some(max_block_value_to_verify) = api.relay_config.constraints_api_config.max_block_value_to_verify {
+            if payload.value() > max_block_value_to_verify {
+                info!(
+                    request_id = %request_id,
+                    block_value = %payload.value(),
+                    "block value is greater than max value to verify, skipping inclusion proof verification",
+                );
+                return Ok(());
+            }
+        }
+
+        if let Some(constraints) = api.auctioneer.get_constraints(payload.slot()).await? {
+            let transactions_root: B256 = payload
+                .transactions()
+                .clone()
+                .hash_tree_root()?
+                .to_vec()
+                .as_slice()
+                .try_into()
+                .map_err(|e| {
+                    error!(error = %e, "failed to convert root to hash32");
+                    BuilderApiError::InternalError
+                })?;
+            let proofs = payload.proofs().ok_or(BuilderApiError::InclusionProofsNotFound)?;
+            let constraints_proofs: Vec<_> = constraints.iter().map(|c| &c.proof_data).collect();
+
+            verify_multiproofs(constraints_proofs.as_slice(), proofs, transactions_root).map_err(
+                |e| {
+                    error!(error = %e, "failed to verify inclusion proofs");
+                    BuilderApiError::InclusionProofVerificationFailed(e)
+                },
+            )?;
+
+            // Save inclusion proof to auctioneer.
+            api.save_inclusion_proof(
+                payload.slot(),
+                payload.proposer_public_key(),
+                payload.block_hash(),
+                proofs,
+                &request_id,
+            )
+            .await?;
+            info!(request_id = %request_id, head_slot, "inclusion proofs verified and saved to auctioneer");
+        } else {
+            info!(request_id = %request_id, "no constraints found for slot, proof verification is not needed");
+        };
+        Ok(())
+    }    
 }
 
 // STATE SYNC

--- a/crates/api/src/builder/error.rs
+++ b/crates/api/src/builder/error.rs
@@ -166,6 +166,9 @@ pub enum BuilderApiError {
 
     #[error("incorrect slot for constraints request {0}")]
     IncorrectSlot(u64),
+
+    #[error("relay side inclusion proof verification failed")]
+    RelaySideInclusionProofVerificationFailed,
 }
 
 impl IntoResponse for BuilderApiError {
@@ -335,6 +338,9 @@ impl IntoResponse for BuilderApiError {
             }
             BuilderApiError::IncorrectSlot(slot) => {
                 (StatusCode::BAD_REQUEST, format!("incorrect slot for constraints request {slot}")).into_response()
+            }
+            BuilderApiError::RelaySideInclusionProofVerificationFailed => {
+                (StatusCode::BAD_REQUEST, "relay side inclusion proof verification failed").into_response()
             }
         }
     }

--- a/crates/api/src/proposer/tests.rs
+++ b/crates/api/src/proposer/tests.rs
@@ -997,8 +997,8 @@ mod proposer_api_tests {
             Arc::new(ChainInfo::for_holesky()),
             slot_update_sender.clone(),
             Arc::new(ValidatorPreferences::default()),
-            0,
             gossip_receiver,
+            Arc::new(Default::default()),
         );
 
         let mut x = gen_signed_vr();

--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -182,8 +182,8 @@ impl ApiService {
             chain_info.clone(),
             slot_update_sender.clone(),
             validator_preferences.clone(),
-            config.target_get_payload_propagation_duration_ms,
             proposer_gossip_receiver,
+            config.clone(),
         ));
 
         let data_api = Arc::new(DataApiProd::new(validator_preferences.clone(), db.clone()));

--- a/crates/api/src/test_utils.rs
+++ b/crates/api/src/test_utils.rs
@@ -56,8 +56,8 @@ pub fn app() -> Router {
         Arc::new(ChainInfo::for_mainnet()),
         slot_update_sender,
         Arc::new(ValidatorPreferences::default()),
-        0,
         gossip_receiver,
+        Arc::new(Default::default()),
     ));
 
     let data_api = Arc::new(DataApi::<MockDatabaseService>::new(
@@ -218,8 +218,8 @@ pub fn proposer_api_app() -> (
         Arc::new(ChainInfo::for_mainnet()),
         slot_update_sender.clone(),
         Arc::new(ValidatorPreferences::default()),
-        0,
         gossip_receiver,
+        Arc::new(Default::default()),
     ));
 
     let router = Router::new()

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -142,6 +142,9 @@ pub struct ConstraintsApiConfig {
     /// Only verify and save inclusion proofs if the block value is less than this threshold.
     /// We do this to ensure that high value blocks are not rejected.
     pub max_block_value_to_verify_wei: Option<U256>,
+    /// If true, submissions for slots with constraints but, without inclusion proofs
+    /// will be allowed. Constraint validity will be verified in the relay.
+    pub allow_relay_side_constraint_validation: bool,
 }
 
 impl Default for ConstraintsApiConfig {
@@ -149,6 +152,7 @@ impl Default for ConstraintsApiConfig {
         ConstraintsApiConfig {
             check_constraints_signature: true,
             max_block_value_to_verify_wei: None,
+            allow_relay_side_constraint_validation: false,
         }
     }
 }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -136,6 +136,10 @@ pub struct ConstraintsApiConfig {
     /// [`/constraints/v1/builder/constraints`](https://docs.boltprotocol.xyz/technical-docs/api/builder#constraints)
     /// endpoint will not be checked.
     pub check_constraints_signature: bool,
+    /// Only verify and save inclusion proofs if the block value is less than this threshold.
+    /// We do this to ensure that high value blocks are not rejected.
+    #[serde(default)]
+    pub max_block_value_to_verify: Option<u64>,
 }
 
 impl Default for ConstraintsApiConfig {

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1,6 +1,9 @@
 use crate::{api::*, BuilderInfo, ValidatorPreferences};
 use clap::Parser;
-use ethereum_consensus::{primitives::BlsPublicKey, ssz::prelude::Node};
+use ethereum_consensus::{
+    primitives::BlsPublicKey,
+    ssz::prelude::{Node, U256},
+};
 use helix_utils::{
     request_encoding::Encoding,
     serde::{default_bool, deserialize_url, serialize_url},
@@ -138,13 +141,15 @@ pub struct ConstraintsApiConfig {
     pub check_constraints_signature: bool,
     /// Only verify and save inclusion proofs if the block value is less than this threshold.
     /// We do this to ensure that high value blocks are not rejected.
-    #[serde(default)]
-    pub max_block_value_to_verify: Option<u64>,
+    pub max_block_value_to_verify_wei: Option<U256>,
 }
 
 impl Default for ConstraintsApiConfig {
     fn default() -> Self {
-        ConstraintsApiConfig { check_constraints_signature: true }
+        ConstraintsApiConfig {
+            check_constraints_signature: true,
+            max_block_value_to_verify_wei: None,
+        }
     }
 }
 


### PR DESCRIPTION
to allow for testing we allow builders to submit without inclusion proofs and verify the constraints by checking the tx bytes