### PR TITLE
refactor(api/builder): `submit_block`(`_with_proofs`) now have same impl

### DIFF
--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -86,8 +86,7 @@ pub fn build_router(
                 router = router.route(&route.path(), post(BuilderApiProd::submit_block_v2));
             }
             Route::SubmitBlockWithProofs => {
-                router =
-                    router.route(&route.path(), post(BuilderApiProd::submit_block_with_proofs));
+                router = router.route(&route.path(), post(BuilderApiProd::submit_block));
             }
             Route::SubmitHeader => {
                 router = router.route(&route.path(), post(BuilderApiProd::submit_header));


### PR DESCRIPTION
Drops the `submit_block_with_proofs` function handler and modifies the `submit_block` to also check constraints and verify proofs is constraints are available. 

We always need to perform this check because otherwise a builder might trick the relay into accepting as best bid a block without invalid inclusion proofs when they are needed.