### PR TITLE
fix(constraints-api): don't read from db for checking proposer duties

### DIFF
--- a/crates/api/src/constraints/tests.rs
+++ b/crates/api/src/constraints/tests.rs
@@ -152,7 +152,7 @@ async fn send_request(req_url: &str, encoding: Encoding, req_payload: Vec<u8>) -
 async fn start_api_server() -> (
     oneshot::Sender<()>,
     HttpServiceConfig,
-    Arc<ConstraintsApi<MockAuctioneer, MockDatabaseService>>,
+    Arc<ConstraintsApi<MockAuctioneer>>,
     Arc<BuilderApi<MockAuctioneer, MockDatabaseService, MockSimulator, MockGossiper>>,
     Receiver<Sender<ChainUpdate>>,
 ) {

--- a/crates/api/src/router.rs
+++ b/crates/api/src/router.rs
@@ -46,7 +46,7 @@ pub type ProposerApiProd = ProposerApi<
 
 pub type DataApiProd = DataApi<PostgresDatabaseService>;
 
-pub type ConstraintsApiProd = ConstraintsApi<RedisCache, PostgresDatabaseService>;
+pub type ConstraintsApiProd = ConstraintsApi<RedisCache>;
 
 pub fn build_router(
     router_config: &mut RouterConfig,

--- a/crates/api/src/service.rs
+++ b/crates/api/src/service.rs
@@ -190,8 +190,8 @@ impl ApiService {
 
         let constraints_api = Arc::new(ConstraintsApiProd::new(
             auctioneer.clone(),
-            db.clone(),
             chain_info.clone(),
+            slot_update_sender.clone(),
             constraints_handle,
             constraints_api_config,
         ));

--- a/crates/api/src/test_utils.rs
+++ b/crates/api/src/test_utils.rs
@@ -298,7 +298,7 @@ pub fn data_api_app() -> (Router, Arc<DataApi<MockDatabaseService>>, Arc<MockDat
 #[allow(clippy::type_complexity)]
 pub fn constraints_api_app() -> (
     Router,
-    Arc<ConstraintsApi<MockAuctioneer, MockDatabaseService>>,
+    Arc<ConstraintsApi<MockAuctioneer>>,
     Arc<BuilderApi<MockAuctioneer, MockDatabaseService, MockSimulator, MockGossiper>>,
     Receiver<Sender<ChainUpdate>>,
 ) {
@@ -322,14 +322,13 @@ pub fn constraints_api_app() -> (
         );
     let builder_api_service = Arc::new(builder_api_service);
 
-    let constraints_api_service =
-        Arc::new(ConstraintsApi::<MockAuctioneer, MockDatabaseService>::new(
-            auctioneer.clone(),
-            database.clone(),
-            Arc::new(ChainInfo::for_mainnet()),
-            handler,
-            Arc::new(ConstraintsApiConfig::default()),
-        ));
+    let constraints_api_service = Arc::new(ConstraintsApi::<MockAuctioneer>::new(
+        auctioneer.clone(),
+        Arc::new(ChainInfo::for_mainnet()),
+        slot_update_sender,
+        handler,
+        Arc::new(ConstraintsApiConfig::default()),
+    ));
 
     let router = Router::new()
         .route(
@@ -358,15 +357,15 @@ pub fn constraints_api_app() -> (
         )
         .route(
             &Route::SubmitBuilderConstraints.path(),
-            post(ConstraintsApi::<MockAuctioneer, MockDatabaseService>::submit_constraints),
+            post(ConstraintsApi::<MockAuctioneer>::submit_constraints),
         )
         .route(
             &Route::DelegateSubmissionRights.path(),
-            post(ConstraintsApi::<MockAuctioneer, MockDatabaseService>::delegate),
+            post(ConstraintsApi::<MockAuctioneer>::delegate),
         )
         .route(
             &Route::RevokeSubmissionRights.path(),
-            post(ConstraintsApi::<MockAuctioneer, MockDatabaseService>::revoke),
+            post(ConstraintsApi::<MockAuctioneer>::revoke),
         )
         .layer(RequestBodyLimitLayer::new(MAX_PAYLOAD_LENGTH))
         .layer(Extension(builder_api_service.clone()))

--- a/crates/common/src/api/constraints_api.rs
+++ b/crates/common/src/api/constraints_api.rs
@@ -31,8 +31,8 @@ impl SignableBLS for DelegationMessage {
     fn digest(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update([self.action]);
-        hasher.update(&self.validator_pubkey.to_vec());
-        hasher.update(&self.delegatee_pubkey.to_vec());
+        hasher.update(self.validator_pubkey.as_slice());
+        hasher.update(self.delegatee_pubkey.as_slice());
 
         hasher.finalize().into()
     }
@@ -55,8 +55,8 @@ impl SignableBLS for RevocationMessage {
     fn digest(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update([self.action]);
-        hasher.update(&self.validator_pubkey.to_vec());
-        hasher.update(&self.delegatee_pubkey.to_vec());
+        hasher.update(self.validator_pubkey.as_slice());
+        hasher.update(self.delegatee_pubkey.as_slice());
 
         hasher.finalize().into()
     }

--- a/crates/common/src/proofs.rs
+++ b/crates/common/src/proofs.rs
@@ -5,7 +5,7 @@ use ethereum_consensus::{
     primitives::{BlsPublicKey, BlsSignature},
     ssz::prelude::*,
 };
-use reth_primitives::{PooledTransactionsElement, TxHash, B256};
+use reth_primitives::{Bytes, PooledTransactionsElement, TxHash, B256};
 use sha2::{Digest, Sha256};
 use tree_hash::Hash256;
 
@@ -90,9 +90,11 @@ impl TryFrom<SignedConstraints> for SignedConstraintsWithProofData {
 
     fn try_from(value: SignedConstraints) -> Result<Self, ProofError> {
         let mut transactions = Vec::with_capacity(value.message.transactions.len());
-        for transaction in value.message.transactions.to_vec().iter() {
-            let tx = PooledTransactionsElement::decode_enveloped(transaction.to_vec().into())
-                .map_err(|e| ProofError::DecodingFailed(e.to_string()))?;
+        for transaction in value.message.transactions.iter() {
+            let tx = PooledTransactionsElement::decode_enveloped(Bytes::copy_from_slice(
+                transaction.as_slice(),
+            ))
+            .map_err(|e| ProofError::DecodingFailed(e.to_string()))?;
 
             let tx_hash = *tx.hash();
 

--- a/crates/housekeeper/src/chain_event_updater.rs
+++ b/crates/housekeeper/src/chain_event_updater.rs
@@ -36,7 +36,7 @@ pub struct PayloadAttributesUpdate {
 }
 
 /// Payload for head event updates sent to subscribers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SlotUpdate {
     pub slot: u64,
     pub next_duty: Option<BuilderGetValidatorsResponseEntry>,


### PR DESCRIPTION
This PR drops the DB requirement for running the constraints API, and relies on the chain event updater for receiving proposer duties. The implementation matches what has been done in other apis, for example the proposer api.

Related discussion: https://github.com/gattaca-com/helix/pull/49#discussion_r1857212656
Closes #13 

Tested on devnet